### PR TITLE
缺少 dist/web 时提示构建 Web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ npm install -g coding-tool
 ```bash
 git clone https://github.com/CooperJiang/cc-tool.git
 cd cc-tool
-npm install && npm link
+npm install
+npm run build:web   # 构建 Web UI 到 dist/web，避免 ct ui 提示 Cannot GET /
+npm link
 ```
 
 ### 验证安装


### PR DESCRIPTION
 变更                                                                                                                  
  - 服务启动时检测 dist/web，不存在则返回 503 并提示运行 npm run build:web，避免 “Cannot GET /”                            
  - 日志给出缺少前端资源时的构建/开发模式指引                                                                              
  - README 源码安装步骤加入 npm run build:web，避免漏掉前端构建                                                            
                                                                                                                           
 测试                                                                                                                  
  - npm run build:web  